### PR TITLE
Do not call contains() for finder

### DIFF
--- a/src/Detector/Adapter/DrupalAdapter.php
+++ b/src/Detector/Adapter/DrupalAdapter.php
@@ -45,9 +45,7 @@ class DrupalAdapter implements AdapterInterface
     public function appendDetectionCriteria(Finder $finder)
     {
         $finder->name('system.info')
-            ->contains('project = "drupal"')
-            ->name('system.info.yml')
-            ->contains("project: 'drupal'");
+            ->name('system.info.yml');
 
         return $finder;
     }

--- a/src/Detector/Adapter/JoomlaAdapter.php
+++ b/src/Detector/Adapter/JoomlaAdapter.php
@@ -81,8 +81,7 @@ class JoomlaAdapter implements AdapterInterface
      */
     public function appendDetectionCriteria(Finder $finder)
     {
-        $finder->name('configuration.php')
-               ->contains('class JConfig');
+        $finder->name('configuration.php');
 
         return $finder;
     }

--- a/src/Detector/Adapter/WordpressAdapter.php
+++ b/src/Detector/Adapter/WordpressAdapter.php
@@ -29,8 +29,7 @@ class WordpressAdapter implements AdapterInterface
      */
     public function appendDetectionCriteria(Finder $finder)
     {
-        $finder->name('version.php')
-            ->contains('$wp_version =');
+        $finder->name('version.php');
 
         return $finder;
     }

--- a/tests/suites/adapters/DrupalAdapterTest.php
+++ b/tests/suites/adapters/DrupalAdapterTest.php
@@ -19,6 +19,9 @@ use Symfony\Component\Finder\Finder;
  */
 class DrupalAdapterTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var DrupalAdapter
+     */
     public $object;
 
     public function setUp()
@@ -35,7 +38,7 @@ class DrupalAdapterTest extends \PHPUnit_Framework_TestCase
     {
         $finder = new Finder();
         $finder->files()->in(CMSSCANNER_MOCKFILES_PATH)
-            ->name('dummy.php')->contains('#content');
+            ->name('dummy.php');
 
         $finder = $this->object->appendDetectionCriteria($finder);
 

--- a/tests/suites/adapters/JoomlaAdapterTest.php
+++ b/tests/suites/adapters/JoomlaAdapterTest.php
@@ -19,6 +19,7 @@ use Symfony\Component\Finder\Finder;
  */
 class JoomlaAdapterTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var JoomlaAdapter */
     public $object;
 
     public function setUp()
@@ -35,8 +36,8 @@ class JoomlaAdapterTest extends \PHPUnit_Framework_TestCase
     {
         $finder = new Finder();
         $finder->files()->in(CMSSCANNER_MOCKFILES_PATH)
-            ->name('dummy.php')->contains('#content')
-            ->name('configuration.php')->contains('#empty');
+            ->name('dummy.php')
+            ->name('configuration.php');
 
         $finder = $this->object->appendDetectionCriteria($finder);
 

--- a/tests/suites/adapters/WordpressAdapterTest.php
+++ b/tests/suites/adapters/WordpressAdapterTest.php
@@ -19,6 +19,9 @@ use Symfony\Component\Finder\Finder;
  */
 class WordpressAdapterTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var WordpressAdapter
+     */
     public $object;
 
     public function setUp()
@@ -35,8 +38,8 @@ class WordpressAdapterTest extends \PHPUnit_Framework_TestCase
     {
         $finder = new Finder();
         $finder->files()->in(CMSSCANNER_MOCKFILES_PATH)
-            ->name('dummy.php')->contains('#content')
-            ->name('version.php')->contains('#empty');
+            ->name('dummy.php')
+            ->name('version.php');
 
         $finder = $this->object->appendDetectionCriteria($finder);
 
@@ -58,7 +61,7 @@ class WordpressAdapterTest extends \PHPUnit_Framework_TestCase
         }
 
         $this->assertCount(5, $results);
-        $this->assertEquals(2, $falseCount);
+        $this->assertEquals(10, $falseCount);
         $this->assertArrayHasKey('', $results);
         $this->assertArrayHasKey('2.2.1', $results);
         $this->assertArrayHasKey('2.9', $results);


### PR DESCRIPTION
The contains() filters seem to be executed with logical AND
after the file name filters.
This completely kills the detection.
(The unit tests did work because every test gets its own finder instance)
