### PR TITLE
Implement the version checks for the newest joomla versions

### DIFF
--- a/src/Detector/Adapter/JoomlaAdapter.php
+++ b/src/Detector/Adapter/JoomlaAdapter.php
@@ -77,6 +77,11 @@ class JoomlaAdapter implements AdapterInterface
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
+            "regex" => "/\\\$RELEASE\\s*=\\s*'3\\.5';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "minor" => "3.5."
+        ),
+        array(
+            "file" => "/libraries/cms/version/version.php",
             "regex" => "/\\\$RELEASE\\s*=\\s*'3\\.6';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.6."
         ),

--- a/src/Detector/Adapter/JoomlaAdapter.php
+++ b/src/Detector/Adapter/JoomlaAdapter.php
@@ -74,7 +74,27 @@ class JoomlaAdapter implements AdapterInterface
             "file" => "/libraries/cms/version/version.php",
             "regex" => "/\\\$RELEASE\\s*=\\s*'3\\.4';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.4."
-        )
+        ),
+        array(
+            "file" => "/libraries/cms/version/version.php",
+            "regex" => "/\\\$RELEASE\\s*=\\s*'3\\.6';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "minor" => "3.6."
+        ),
+        array(
+            "file" => "/libraries/cms/version/version.php",
+            "regex" => "/\\\$RELEASE\\s*=\\s*'3\\.7';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "minor" => "3.7."
+        ),
+        array(
+            "file" => "/libraries/cms/version/version.php",
+            "regex" => "/\\\$RELEASE\\s*=\\s*'3\\.8';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "minor" => "3.8."
+        ),
+        array(
+            "file" => "/libraries/cms/version/version.php",
+            "regex" => "/\\\$RELEASE\\s*=\\s*'4\\.0';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "minor" => "4.0."
+        ),
     );
 
     /**

--- a/src/Detector/Adapter/JoomlaAdapter.php
+++ b/src/Detector/Adapter/JoomlaAdapter.php
@@ -24,83 +24,15 @@ class JoomlaAdapter implements AdapterInterface
      * Joomla has changed the way how the version number is stored multiple times, so we need this comprehensive array
      * @var array
      */
-    private $versions = array(
-        array(
-            "file" => "/includes/version.php",
-            "regex" => "/\\\$?RELEASE\\s*=\\s*'1\\.0';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
-            "minor" => "1.0."
-        ),
-        array(
-            "file" => "/libraries/joomla/version.php",
-            "regex" => "/\\\$?RELEASE\\s*=\\s*'1\\.5';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
-            "minor" => "1.5."
-        ),
-        array(
-            "file" => "/libraries/joomla/version.php",
-            "regex" => "/\\\$?RELEASE\\s*=\\s*'1\\.6';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
-            "minor" => "1.6."
-        ),
-        array(
-            "file" => "/includes/version.php",
-            "regex" => "/\\\$?RELEASE\\s*=\\s*'1\\.7';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
-            "minor" => "1.7."
-        ),
-        array(
-            "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$?RELEASE\\s*=\\s*'2\\.5';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
-            "minor" => "2.5."
-        ),
-        array(
-            "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.0';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
-            "minor" => "3.0."
-        ),
-        array(
-            "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.1';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
-            "minor" => "3.1."
-        ),
-        array(
-            "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.2';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
-            "minor" => "3.2."
-        ),
-        array(
-            "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.3';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
-            "minor" => "3.3."
-        ),
-        array(
-            "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.4';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
-            "minor" => "3.4."
-        ),
-        array(
-            "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.5';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
-            "minor" => "3.5."
-        ),
-        array(
-            "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.6';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
-            "minor" => "3.6."
-        ),
-        array(
-            "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.7';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
-            "minor" => "3.7."
-        ),
-        array(
-            "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.8';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
-            "minor" => "3.8."
-        ),
-        array(
-            "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$?RELEASE\\s*=\\s*'4\\.0';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
-            "minor" => "4.0."
-        ),
-    );
+    private $version = array(
+            "files" => array(
+                "/includes/version.php",
+                "/libraries/joomla/version.php",
+                "/libraries/cms/version/version.php",
+            ),
+            "regex_release" => "/\\\$?RELEASE\s*=\s*'([\d.]+)';/",
+            "regex_devlevel" => "/\\\$?DEV_LEVEL\s*=\s*'([^']+)';/",
+        );
 
     /**
      * Joomla has a file called configuration.php that can be used to search for working installations
@@ -165,24 +97,36 @@ class JoomlaAdapter implements AdapterInterface
     public function detectVersion(\SplFileInfo $path)
     {
         // Iterate through version patterns
-        foreach ($this->versions as $version) {
-            $versionFile = $path->getRealPath() . $version['file'];
+        foreach ($this->version['files'] as $file)
+        {
+            $versionFile = $path->getRealPath() . $file;
 
-            if (!file_exists($versionFile)) {
+            if (!file_exists($versionFile))
+            {
                 continue;
             }
 
-            if (!is_readable($versionFile)) {
+            if (!is_readable($versionFile))
+            {
                 continue; // @codeCoverageIgnore
             }
 
-            preg_match($version['regex'], file_get_contents($versionFile), $matches);
+            //$fileContent = file_get_contents($versionFile);
 
-            if (!count($matches)) {
+            preg_match($this->version['regex_release'], file_get_contents($versionFile), $release);
+            preg_match($this->version['regex_devlevel'], file_get_contents($versionFile), $devlevel);
+
+            if (!count($release))
+            {
                 continue;
             }
 
-            return $version['minor'] . $matches[1];
+            if (!count($devlevel))
+            {
+                return $release[1] . '.x';
+            }
+
+            return $release[1] . '.' . $devlevel[1];
         }
 
         return null;

--- a/src/Detector/Adapter/JoomlaAdapter.php
+++ b/src/Detector/Adapter/JoomlaAdapter.php
@@ -97,30 +97,25 @@ class JoomlaAdapter implements AdapterInterface
     public function detectVersion(\SplFileInfo $path)
     {
         // Iterate through version files
-        foreach ($this->version['files'] as $file)
-        {
+        foreach ($this->version['files'] as $file) {
             $versionFile = $path->getRealPath() . $file;
 
-            if (!file_exists($versionFile))
-            {
+            if (!file_exists($versionFile)) {
                 continue;
             }
 
-            if (!is_readable($versionFile))
-            {
+            if (!is_readable($versionFile)) {
                 continue; // @codeCoverageIgnore
             }
 
             preg_match($this->version['regex_release'], file_get_contents($versionFile), $release);
             preg_match($this->version['regex_devlevel'], file_get_contents($versionFile), $devlevel);
 
-            if (!count($release))
-            {
+            if (!count($release)) {
                 continue;
             }
 
-            if (!count($devlevel))
-            {
+            if (!count($devlevel)) {
                 return $release[1] . '.x';
             }
 

--- a/src/Detector/Adapter/JoomlaAdapter.php
+++ b/src/Detector/Adapter/JoomlaAdapter.php
@@ -27,77 +27,77 @@ class JoomlaAdapter implements AdapterInterface
     private $versions = array(
         array(
             "file" => "/includes/version.php",
-            "regex" => "/\\\?RELEASE\\s*=\\s*'1\\.0';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\$?RELEASE\\s*=\\s*'1\\.0';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "1.0."
         ),
         array(
             "file" => "/libraries/joomla/version.php",
-            "regex" => "/\\\?RELEASE\\s*=\\s*'1\\.5';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\$?RELEASE\\s*=\\s*'1\\.5';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "1.5."
         ),
         array(
             "file" => "/libraries/joomla/version.php",
-            "regex" => "/\\\?RELEASE\\s*=\\s*'1\\.6';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\$?RELEASE\\s*=\\s*'1\\.6';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "1.6."
         ),
         array(
             "file" => "/includes/version.php",
-            "regex" => "/\\\?RELEASE\\s*=\\s*'1\\.7';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\$?RELEASE\\s*=\\s*'1\\.7';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "1.7."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\?RELEASE\\s*=\\s*'2\\.5';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\$?RELEASE\\s*=\\s*'2\\.5';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "2.5."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.0';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.0';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.0."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.1';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.1';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.1."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.2';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.2';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.2."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.3';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.3';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.3."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.4';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.4';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.4."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.5';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.5';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.5."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.6';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.6';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.6."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.7';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.7';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.7."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.8';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\$?RELEASE\\s*=\\s*'3\\.8';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.8."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\?RELEASE\\s*=\\s*'4\\.0';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\$?RELEASE\\s*=\\s*'4\\.0';[\\s\\S]*\\\$?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "4.0."
         ),
     );

--- a/src/Detector/Adapter/JoomlaAdapter.php
+++ b/src/Detector/Adapter/JoomlaAdapter.php
@@ -27,77 +27,77 @@ class JoomlaAdapter implements AdapterInterface
     private $versions = array(
         array(
             "file" => "/includes/version.php",
-            "regex" => "/\\\$RELEASE\\s*=\\s*'1\\.0';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\?RELEASE\\s*=\\s*'1\\.0';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "1.0."
         ),
         array(
             "file" => "/libraries/joomla/version.php",
-            "regex" => "/\\\$RELEASE\\s*=\\s*'1\\.5';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\?RELEASE\\s*=\\s*'1\\.5';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "1.5."
         ),
         array(
             "file" => "/libraries/joomla/version.php",
-            "regex" => "/\\\$RELEASE\\s*=\\s*'1\\.6';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\?RELEASE\\s*=\\s*'1\\.6';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "1.6."
         ),
         array(
             "file" => "/includes/version.php",
-            "regex" => "/\\\$RELEASE\\s*=\\s*'1\\.7';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\?RELEASE\\s*=\\s*'1\\.7';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "1.7."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$RELEASE\\s*=\\s*'2\\.5';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\?RELEASE\\s*=\\s*'2\\.5';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "2.5."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$RELEASE\\s*=\\s*'3\\.0';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.0';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.0."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$RELEASE\\s*=\\s*'3\\.1';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.1';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.1."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$RELEASE\\s*=\\s*'3\\.2';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.2';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.2."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$RELEASE\\s*=\\s*'3\\.3';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.3';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.3."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$RELEASE\\s*=\\s*'3\\.4';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.4';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.4."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$RELEASE\\s*=\\s*'3\\.5';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.5';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.5."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$RELEASE\\s*=\\s*'3\\.6';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.6';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.6."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$RELEASE\\s*=\\s*'3\\.7';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.7';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.7."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$RELEASE\\s*=\\s*'3\\.8';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\?RELEASE\\s*=\\s*'3\\.8';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "3.8."
         ),
         array(
             "file" => "/libraries/cms/version/version.php",
-            "regex" => "/\\\$RELEASE\\s*=\\s*'4\\.0';[\\s\\S]*\\\$DEV_LEVEL\\s*=\\s*'([^']+)'/",
+            "regex" => "/\\\?RELEASE\\s*=\\s*'4\\.0';[\\s\\S]*\\\?DEV_LEVEL\\s*=\\s*'([^']+)'/",
             "minor" => "4.0."
         ),
     );

--- a/src/Detector/Adapter/JoomlaAdapter.php
+++ b/src/Detector/Adapter/JoomlaAdapter.php
@@ -96,7 +96,7 @@ class JoomlaAdapter implements AdapterInterface
      */
     public function detectVersion(\SplFileInfo $path)
     {
-        // Iterate through version patterns
+        // Iterate through version files
         foreach ($this->version['files'] as $file)
         {
             $versionFile = $path->getRealPath() . $file;
@@ -110,8 +110,6 @@ class JoomlaAdapter implements AdapterInterface
             {
                 continue; // @codeCoverageIgnore
             }
-
-            //$fileContent = file_get_contents($versionFile);
 
             preg_match($this->version['regex_release'], file_get_contents($versionFile), $release);
             preg_match($this->version['regex_devlevel'], file_get_contents($versionFile), $devlevel);


### PR DESCRIPTION
Implement the version checks for the newest joomla versions

### How to test

- install multibe joomla versions
- run  ./bin/cmsscanner cmsscanner:detect /var/www --versions

### Expected result after the patch

```
Successfully finished scan!
CMSScanner found 6 CMS installations!

+-----------+-----------------+
| CMS       | # Installations |
+-----------+-----------------+
| Joomla    | 4               |
| Drupal    | 1               |
| WordPress | 1               |
+-----------+-----------------+

Version specific stats:
Joomla:
+---------+-----------------+
| Version | # Installations |
+---------+-----------------+
| Unknown | 0               |
| 1.5.26  | 1               |
| 2.5.27  | 1               |
| 3.6.0   | 1               |
| 3.6.5   | 1               |
+---------+-----------------+
Drupal:
+---------+-----------------+
| Version | # Installations |
+---------+-----------------+
| Unknown | 0               |
| 8.2.7   | 1               |
+---------+-----------------+
WordPress:
+---------+-----------------+
| Version | # Installations |
+---------+-----------------+
| Unknown | 0               |
| 4.7.3   | 1               |
+---------+-----------------+

Execution time: 1.2367210388184 seconds
Memory consumption: 4M

```

### Actual result

```
Successfully finished scan!
CMSScanner found 5 CMS installations!

+-----------+-----------------+
| CMS       | # Installations |
+-----------+-----------------+
| Joomla    | 3               |
| Drupal    | 1               |
| WordPress | 1               |
+-----------+-----------------+

Version specific stats:
Joomla:
+---------+-----------------+
| Version | # Installations |
+---------+-----------------+
| Unknown | 3               |
+---------+-----------------+
Drupal:
+---------+-----------------+
| Version | # Installations |
+---------+-----------------+
| Unknown | 0               |
| 8.2.7   | 1               |
+---------+-----------------+
WordPress:
+---------+-----------------+
| Version | # Installations |
+---------+-----------------+
| Unknown | 0               |
| 4.7.3   | 1               |
+---------+-----------------+

Execution time: 0.83501696586609 seconds
Memory consumption: 4M

```

### Additional comments

Thanks to @nullbytes for the help with the regex!