### PR TITLE
[DrupalAdapter] Fix Travis error after #60

### DIFF
--- a/tests/suites/adapters/DrupalAdapterTest.php
+++ b/tests/suites/adapters/DrupalAdapterTest.php
@@ -132,7 +132,7 @@ class DrupalAdapterTest extends \PHPUnit_Framework_TestCase
                     'type' => 'module',
                 );
                 $this->assertEquals($expected, (array)$modules[5]);
-                
+
                 $expected = array(
                     'name' => 'devel',
                     'path' => $path->getRealPath().'/sites/mysite/modules/contrib/devel',
@@ -140,8 +140,6 @@ class DrupalAdapterTest extends \PHPUnit_Framework_TestCase
                     'type' => 'module',
                 );
                 $this->assertEquals($expected, (array)$modules[6]);
-
-
             } elseif ($version === 8) {
                 $this->assertCount(1, $modules);
                 $this->assertInstanceOf('Cmsgarden\Cmsscanner\Detector\Module', $modules[0]);

--- a/tests/suites/adapters/DrupalAdapterTest.php
+++ b/tests/suites/adapters/DrupalAdapterTest.php
@@ -126,20 +126,22 @@ class DrupalAdapterTest extends \PHPUnit_Framework_TestCase
                 $this->assertEquals($expected, (array)$modules[4]);
 
                 $expected = array(
-                    'name' => 'devel',
-                    'path' => $path->getRealPath().'/sites/mysite/modules/contrib/devel',
-                    'version' => '7.x-1.5',
-                    'type' => 'module',
-                );
-                $this->assertEquals($expected, (array)$modules[5]);
-
-                $expected = array(
                     'name' => 'views_bulk_operations',
                     'path' => $path->getRealPath().'/sites/mysite/modules/contrib/views_bulk_operations',
                     'version' => '7.x-3.3',
                     'type' => 'module',
                 );
+                $this->assertEquals($expected, (array)$modules[5]);
+                
+                $expected = array(
+                    'name' => 'devel',
+                    'path' => $path->getRealPath().'/sites/mysite/modules/contrib/devel',
+                    'version' => '7.x-1.5',
+                    'type' => 'module',
+                );
                 $this->assertEquals($expected, (array)$modules[6]);
+
+
             } elseif ($version === 8) {
                 $this->assertCount(1, $modules);
                 $this->assertInstanceOf('Cmsgarden\Cmsscanner\Detector\Module', $modules[0]);


### PR DESCRIPTION
This here tries to fix the drupal travis error reported here #65 by reverting this change here: https://github.com/CMS-Garden/cmsscanner/commit/f05f1a12e11c580caa2026b7e65dc139f00e7023#diff-7383f15d436a88fa320e7b9e19ca7cfa from @antondollmaier & @SniperSister